### PR TITLE
Bugfix 0003_auto_20170928_0908.py

### DIFF
--- a/cms_named_menus/migrations/0003_auto_20170928_0908.py
+++ b/cms_named_menus/migrations/0003_auto_20170928_0908.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='cmsnamedmenu',
             name='slug',
-            field=autoslug.fields.AutoSlugField(always_update=True, populate_from=b'name', editable=False),
+            field=autoslug.fields.AutoSlugField(always_update=True, populate_from='name', editable=False),
         ),
     ]


### PR DESCRIPTION
With python 3 i get "missing" migration if "populate_from" value is a binary...